### PR TITLE
Enforce 300 maximum number of lines in a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 group: beta
 language: node_js
 node_js:
-- node
+- 17
 cache:
   directories:
   - node_modules

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
 		'require-await': 'off',
 		'promise/always-return': 'warn',
 		'promise/catch-or-return': ['warn', { allowFinally: true }],
+		'max-lines': ['error', { max: 300 }],
 	},
 
 	overrides: [


### PR DESCRIPTION
Why 300 lines? 300 is the default eslint maximum number of lines in a file

Fixes https://github.com/Collaborne/backlog/issues/688